### PR TITLE
Feat: Translated server errors

### DIFF
--- a/src/app/shared/components/error-message/error-message.component.html
+++ b/src/app/shared/components/error-message/error-message.component.html
@@ -1,0 +1,35 @@
+<div fxLayout="row">
+  <div fxFlex>
+    <mat-list dense>
+      <mat-list-item *ngFor="let error of errors">
+        <div fxLayout="row"
+             fxLayoutAlign="start start"
+        >
+          <span>{{ error.property | translate }}</span>
+
+          <span>&nbsp;-&nbsp;</span>
+
+          <span>{{ error.message | translate }}</span>
+
+          <code *ngIf="!production"
+             matTooltip="{{ 'component.shared.error-message.not-used-production-environment' | translate }}"
+          >
+            &nbsp;({{ error.debug }})
+          </code>
+        </div>
+      </mat-list-item>
+    </mat-list>
+  </div>
+
+  <div fxLayout="column"
+       fxLayoutAlign="end end"
+  >
+    <button mat-button
+            type="button"
+            color="warn"
+            (click)="dismiss()"
+    >
+      {{ 'snackbar.close-button' | translate }}
+    </button>
+  </div>
+</div>

--- a/src/app/shared/components/error-message/error-message.component.scss
+++ b/src/app/shared/components/error-message/error-message.component.scss
@@ -1,0 +1,15 @@
+@import './src/styles/variables';
+
+.mat-list-base[dense] {
+  .mat-list-item {
+    height: auto;
+
+    ::ng-deep {
+      .mat-list-item-content {
+        padding: 0 0 $spacing-half;
+        line-height: 12px;
+        color: rgba(255, 255, 255, .7);
+      }
+    }
+  }
+}

--- a/src/app/shared/components/error-message/error-message.component.ts
+++ b/src/app/shared/components/error-message/error-message.component.ts
@@ -1,0 +1,82 @@
+import { Component, Inject, OnInit } from '@angular/core';
+import { MAT_SNACK_BAR_DATA, MatSnackBarRef } from '@angular/material/snack-bar';
+import { TranslateService } from '@ngx-translate/core';
+import { take } from 'rxjs/operators';
+
+import { ErrorMessageClientInterface, ErrorMessageInterface, ErrorMessageServerInterface } from '../../interfaces';
+import { environment } from '../../../../environments/environment';
+
+@Component({
+  selector: 'app-error-message',
+  templateUrl: './error-message.component.html',
+  styleUrls: ['./error-message.component.scss'],
+})
+
+export class ErrorMessageComponent implements OnInit {
+  public errors: Array<ErrorMessageInterface>;
+  public production = environment.production;
+
+  private static getClientMessage(message: ErrorMessageServerInterface): ErrorMessageClientInterface {
+    const target = message.target.split('.').map(bit => bit.charAt(0).toLowerCase() + bit.slice(1)).join('.');
+
+    return {
+      ...message,
+      messageText: ['server-error', message.code, target, message.propertyPath].join('.'),
+      messageProperty: ['server-error', 'property', target, message.propertyPath].join('.'),
+    };
+  }
+
+  public constructor(
+    @Inject(MAT_SNACK_BAR_DATA) private serverMessages: Array<ErrorMessageServerInterface>,
+    private snackBarRef: MatSnackBarRef<ErrorMessageComponent>,
+    private translateService: TranslateService,
+  ) { }
+
+  public ngOnInit(): void {
+    const clientMessages = this.serverMessages.map(ErrorMessageComponent.getClientMessage);
+
+    this.translateService
+      .get([
+        ...clientMessages.map((message: ErrorMessageClientInterface): string => message.messageText),
+        ...clientMessages.map((message: ErrorMessageClientInterface): string => message.messageProperty),
+      ])
+      .pipe(take(1))
+      .subscribe((texts: {[key: string]: string}): void => {
+        const messages = clientMessages.map(this.processTranslations(texts), clientMessages);
+
+        this.errors = messages.map(
+          (error: ErrorMessageClientInterface): ErrorMessageInterface => ({
+            message: error?.messageTextClient || error.message,
+            property: error?.messagePropertyClient || error.propertyPath,
+            debug: error.target.split('.').join('\\') + '::$' + error.propertyPath,
+          }),
+        );
+      });
+  }
+
+  public dismiss(): void {
+    this.snackBarRef.dismiss();
+  }
+
+  private processTranslations(texts: { [key: string]: string }): (message: ErrorMessageClientInterface) => ErrorMessageClientInterface {
+    return (message: ErrorMessageClientInterface): ErrorMessageClientInterface => {
+      const properties = ['messageProperty', 'messageText'];
+
+      properties.map((property: string): void => {
+        const propertyClient = property + 'Client';
+
+        message[propertyClient] = texts[message[property]];
+
+        if (texts[message[property]] === message[property]) {
+          if (!environment.production) {
+            console.warn('Missing translation! `' + message[property] + '` - This is only shown in non `production` environments.');
+          }
+
+          message[propertyClient] = null;
+        }
+      });
+
+      return message;
+    };
+  }
+}

--- a/src/app/shared/components/index.ts
+++ b/src/app/shared/components/index.ts
@@ -1,5 +1,10 @@
-export { FooterComponent } from './footer/footer.component';
-export { HeaderComponent } from './header/header.component';
+import { ErrorMessageComponent } from './error-message/error-message.component';
+
+export * from './error-message/error-message.component';
+export * from './footer/footer.component';
+export * from './header/header.component';
 
 // Only export components that are used commonly within another modules
-export const Components = [];
+export const Components = [
+  ErrorMessageComponent,
+];

--- a/src/app/shared/interceptors/accept-language.interceptor.ts
+++ b/src/app/shared/interceptors/accept-language.interceptor.ts
@@ -1,0 +1,32 @@
+import { Injectable } from '@angular/core';
+import { HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
+import { LocalStorageService } from 'ngx-webstorage';
+import { Observable } from 'rxjs';
+
+import { ConfigurationService } from '../services';
+import { Language } from '../enums';
+
+@Injectable()
+export class AcceptLanguageInterceptor implements HttpInterceptor {
+  public constructor(private localStorage: LocalStorageService) { }
+
+  public intercept(httpRequest: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+    let output;
+
+    try {
+      if (new URL(httpRequest.url).host === new URL(ConfigurationService.configuration.apiUrl).host) {
+        const modified = httpRequest.clone({
+          setHeaders: {
+            'Accept-Language': this.localStorage.retrieve('language') || Language.DEFAULT,
+          },
+        });
+
+        output = next.handle(modified);
+      }
+    } catch (e) {
+      output = next.handle(httpRequest);
+    }
+
+    return output;
+  }
+}

--- a/src/app/shared/interceptors/index.ts
+++ b/src/app/shared/interceptors/index.ts
@@ -1,7 +1,9 @@
 import { HTTP_INTERCEPTORS } from '@angular/common/http';
 
 import { ErrorInterceptor } from './error.interceptor';
+import { AcceptLanguageInterceptor } from './accept-language.interceptor';
 
 export const HttpInterceptors = [
   { provide: HTTP_INTERCEPTORS, useClass: ErrorInterceptor, multi: true },
+  { provide: HTTP_INTERCEPTORS, useClass: AcceptLanguageInterceptor, multi: true },
 ];

--- a/src/app/shared/interfaces/error-message-client.interface.ts
+++ b/src/app/shared/interfaces/error-message-client.interface.ts
@@ -1,5 +1,8 @@
-import {ErrorMessageServerInterface} from "./error-message-server.interface";
+import {ErrorMessageServerInterface} from './error-message-server.interface';
 
 export interface ErrorMessageClientInterface extends ErrorMessageServerInterface {
-  textTag: string;
+  messageText: string;
+  messageProperty: string;
+  messageTextClient?: string|null;
+  messagePropertyClient?: string|null;
 }

--- a/src/app/shared/interfaces/error-message-server.interface.ts
+++ b/src/app/shared/interfaces/error-message-server.interface.ts
@@ -1,5 +1,6 @@
 export interface ErrorMessageServerInterface {
   code: string;
   message: string;
+  target: string;
   propertyPath: string;
 }

--- a/src/app/shared/interfaces/error-message.interface.ts
+++ b/src/app/shared/interfaces/error-message.interface.ts
@@ -1,0 +1,5 @@
+export interface ErrorMessageInterface {
+  message: string;
+  property: string;
+  debug?: string|null;
+}

--- a/src/app/shared/interfaces/index.ts
+++ b/src/app/shared/interfaces/index.ts
@@ -1,4 +1,6 @@
 export * from './application-configuration-interface';
+export * from './error-message.interface';
+export * from './error-message-client.interface';
 export * from './error-message-server.interface';
 export * from './server-error.interface';
 export * from './server-error-debug.interface';

--- a/src/app/shared/material/material.module.ts
+++ b/src/app/shared/material/material.module.ts
@@ -8,6 +8,8 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatListModule } from '@angular/material/list';
+import { MatTooltipModule } from '@angular/material/tooltip';
 
 // Only add Material modules that are used within _all_ other modules
 const MaterialModules = [
@@ -16,10 +18,12 @@ const MaterialModules = [
   MatFormFieldModule,
   MatIconModule,
   MatInputModule,
+  MatListModule,
   MatMenuModule,
   MatProgressSpinnerModule,
   MatSnackBarModule,
   MatToolbarModule,
+  MatTooltipModule,
 ];
 
 @NgModule({

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -16,7 +16,14 @@ import { Services } from './services';
     ...Components,
     ...Directives,
   ],
-  imports: [],
+  imports: [
+    BrowserAnimationsModule,
+    CommonModule,
+    FlexLayoutModule,
+    ReactiveFormsModule,
+    MaterialModule,
+    TranslateModule,
+  ],
   exports: [
     ...Components,
     ...Directives,

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -25,6 +25,11 @@
           "en": "English"
         }
       }
+    },
+    "shared": {
+      "error-message": {
+        "not-used-production-environment": "This is only shown if Angular `environment` is not `production` - only for debug purposes."
+      }
     }
   },
   "messages": {

--- a/src/assets/i18n/fi.json
+++ b/src/assets/i18n/fi.json
@@ -25,6 +25,11 @@
           "en": "Englanti"
         }
       }
+    },
+    "shared": {
+      "error-message": {
+        "not-used-production-environment": "Tämä on näkyvissä vain jos Angular `environment` ei ole `production` - vain debug tarkoitukseen."
+      }
     }
   },
   "messages": {


### PR DESCRIPTION
This PR adds support to send `Accept-Language` header to backend so that it can use translations as expected in possible error cases. Another quite big thing is that those error messages from backend side can also be translated in frontend side if needed. With these there is following structure for the messages;

```
server-error.{error_uuid}.{target}.{propertyPath}
server-error.property.{target}.{propertyPath}
```

`error_uuid` = Validation constraint UUID from Symfony backend
`target` = Object that trigger error eg. `app.entity.user` or `app.dto.userCreate`
`propertyPath` = Path to property (usually just property name) eg. `username`, `email`, etc.

These messages are shown in separated component so that we can use some custom styling for those. This component is global component, so needed to change `shared.module.ts` structure to import those same modules that we're exporting from that.

Another note is that if you're not running application in `production` mode you will see `console.warn` messages about missing translations so that it should be quite easy job to add those to frontend side if needed.